### PR TITLE
Add support for querying the G13 category counts

### DIFF
--- a/commands/afc_status.py
+++ b/commands/afc_status.py
@@ -82,11 +82,23 @@ class AFCStatus(Command):
                 msg = "Aggregate is \x0305{0}\x0F (AfC {1})."
                 self.reply(data, msg.format(agg_num, aggregate))
 
+            elif action.startswith("g13_eligible") or action = "g13e":
+                g13_eli = self.count_g13_eligible()
+                msg = "There are \x03{0}\x0F G13 eligible pages."
+                self.reply(data, msg.format(g13_eli))
+
+            elif action.startswith("g13_active") or action = "g13a":
+                g13_noms = self.count_g13_active()
+                msg = "There are \x03{0}\x0F active CSD:G13 nominations."
+                self.reply(data, msg.format(g13_noms))
+                
             elif action.startswith("nocolor") or action == "n":
                 self.reply(data, self.get_status(color=False))
 
             else:
-                msg = "Unknown argument: \x0303{0}\x0F. Valid args are 'subs', 'redirs', 'files', 'agg', 'nocolor'."
+                msg = "Unknown argument: \x0303{0}\x0F. Valid args are " +\
+                  "'subs', 'redirs', 'files', 'agg', 'nocolor', " +\
+                  "'g13_eligible', 'g13_active'."
                 self.reply(data, msg.format(data.args[0]))
 
         else:
@@ -105,6 +117,21 @@ class AFCStatus(Command):
             msg = "Articles for creation {0} (AFC: {1}; AFC/R: {2}; FFU: {3})."
         return msg.format(aggregate, subs, redirs, files)
 
+    def count_g13_eligible(self):
+        """
+          Returns the number of G13 Eligible AfC Submissions (count of 
+          Category:G13 eligible AfC submissions)
+        """
+        return self.site.get_category("G13 eligible AfC submissions").pages
+
+    def count_g13_active(self):
+        """
+          Returns the number of active CSD:G13 nominations ( count of
+          Category:Candidates for speedy deletion as abandoned AfC submissions)
+        """
+        cat_name = "Candidates for speedy deletion as abandoned AfC submissions"
+        return self.site.get_category(cat_name)
+        
     def count_submissions(self):
         """Returns the number of open AFC submissions (count of CAT:PEND)."""
         # Subtract two for [[Wikipedia:Articles for creation/Redirects]] and


### PR DESCRIPTION
commit a7729f995b9387dc24d955886ba2150262979da4
Author: Stephen Lecheler stephen.lecheler@gmail.com
Date:   Thu Aug 15 22:44:33 2013 -0500
  Bugfix
commit a6de7776a13e20436b18ff9453553f0cf638f4a9
Author: Stephen Lecheler stephen.lecheler@gmail.com
Date:   Thu Aug 15 22:37:13 2013 -0500

```
Add code to
1. Support counting G13 eligible AfC pages
2. Support counting active CSD:G13 nominations
3. Respond to inquiries regarding these
```
